### PR TITLE
Add theme-only scaffold with configurable sections

### DIFF
--- a/theme/components/pages/AboutUsContent.tsx
+++ b/theme/components/pages/AboutUsContent.tsx
@@ -1,0 +1,34 @@
+import { HeaderSection } from "../sections/header-section";
+import { HeroSection } from "../sections/hero-section";
+import { AboutSection } from "../sections/about-section";
+import { TeamSection } from "../sections/team-section";
+import { ContactSection } from "../sections/contact-section";
+import { FooterSection } from "../sections/footer-section";
+
+const sectionRenderers: Record<string, (props: { data: any }) => JSX.Element> = {
+  header: HeaderSection,
+  aboutUsHero: HeroSection,
+  about: AboutSection,
+  team: TeamSection,
+  contact: ContactSection,
+  footer: FooterSection,
+};
+
+export default function AboutUsContent({ initialData }: { initialData: any }) {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      {initialData?.pages?.["about-us"]?.sections?.map((section: any) => {
+        if (!section.enabled) {
+          return null;
+        }
+
+        const Renderer = sectionRenderers[section.type];
+        if (!Renderer) {
+          return null;
+        }
+
+        return <Renderer key={section.id} data={{ id: section.id, ...section.data }} />;
+      })}
+    </main>
+  );
+}

--- a/theme/components/pages/BlogIndexContent.tsx
+++ b/theme/components/pages/BlogIndexContent.tsx
@@ -1,0 +1,28 @@
+import { HeaderSection } from "../sections/header-section";
+import { BlogListSection } from "../sections/blog-list-section";
+import { FooterSection } from "../sections/footer-section";
+
+const sectionRenderers: Record<string, (props: { data: any }) => JSX.Element> = {
+  header: HeaderSection,
+  blogList: BlogListSection,
+  footer: FooterSection,
+};
+
+export default function BlogIndexContent({ initialData }: { initialData: any }) {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      {initialData?.pages?.["blog-index"]?.sections?.map((section: any) => {
+        if (!section.enabled) {
+          return null;
+        }
+
+        const Renderer = sectionRenderers[section.type];
+        if (!Renderer) {
+          return null;
+        }
+
+        return <Renderer key={section.id} data={{ id: section.id, ...section.data }} />;
+      })}
+    </main>
+  );
+}

--- a/theme/components/pages/BlogPostContent.tsx
+++ b/theme/components/pages/BlogPostContent.tsx
@@ -1,0 +1,32 @@
+import { HeaderSection } from "../sections/header-section";
+import { BlogArticleSection } from "../sections/blog-article-section";
+import { BlogTeaserSection } from "../sections/blog-teaser-section";
+import { ContactSection } from "../sections/contact-section";
+import { FooterSection } from "../sections/footer-section";
+
+const sectionRenderers: Record<string, (props: { data: any }) => JSX.Element> = {
+  header: HeaderSection,
+  blogArticle: BlogArticleSection,
+  blogTeaser: BlogTeaserSection,
+  contact: ContactSection,
+  footer: FooterSection,
+};
+
+export default function BlogPostContent({ initialData }: { initialData: any }) {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      {initialData?.pages?.["blog-post"]?.sections?.map((section: any) => {
+        if (!section.enabled) {
+          return null;
+        }
+
+        const Renderer = sectionRenderers[section.type];
+        if (!Renderer) {
+          return null;
+        }
+
+        return <Renderer key={section.id} data={{ id: section.id, ...section.data }} />;
+      })}
+    </main>
+  );
+}

--- a/theme/components/pages/HomeContent.tsx
+++ b/theme/components/pages/HomeContent.tsx
@@ -1,0 +1,42 @@
+import { HeaderSection } from "../sections/header-section";
+import { HeroSection } from "../sections/hero-section";
+import { FeaturesSection } from "../sections/features-section";
+import { ServicesSection } from "../sections/services-section";
+import { ProcessSection } from "../sections/process-section";
+import { PricingSection } from "../sections/pricing-section";
+import { TestimonialsSection } from "../sections/testimonials-section";
+import { BlogTeaserSection } from "../sections/blog-teaser-section";
+import { ContactSection } from "../sections/contact-section";
+import { FooterSection } from "../sections/footer-section";
+
+const sectionRenderers: Record<string, (props: { data: any }) => JSX.Element> = {
+  header: HeaderSection,
+  hero: HeroSection,
+  features: FeaturesSection,
+  services: ServicesSection,
+  process: ProcessSection,
+  pricing: PricingSection,
+  testimonials: TestimonialsSection,
+  blogTeaser: BlogTeaserSection,
+  contact: ContactSection,
+  footer: FooterSection,
+};
+
+export default function HomeContent({ initialData }: { initialData: any }) {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      {initialData?.pages?.home?.sections?.map((section: any) => {
+        if (!section.enabled) {
+          return null;
+        }
+
+        const Renderer = sectionRenderers[section.type];
+        if (!Renderer) {
+          return null;
+        }
+
+        return <Renderer key={section.id} data={{ id: section.id, ...section.data }} />;
+      })}
+    </main>
+  );
+}

--- a/theme/components/pages/services/ServiceDetail.tsx
+++ b/theme/components/pages/services/ServiceDetail.tsx
@@ -1,0 +1,34 @@
+import { HeaderSection } from "../../sections/header-section";
+import { ServiceHeroSection } from "../../sections/service-hero-section";
+import { ServiceDescriptionSection } from "../../sections/service-description-section";
+import { ServicePricingSection } from "../../sections/service-pricing-section";
+import { ServiceContactSection } from "../../sections/service-contact-section";
+import { FooterSection } from "../../sections/footer-section";
+
+const sectionRenderers: Record<string, (props: { data: any }) => JSX.Element> = {
+  header: HeaderSection,
+  serviceHero: ServiceHeroSection,
+  serviceDescription: ServiceDescriptionSection,
+  servicePricing: ServicePricingSection,
+  serviceContact: ServiceContactSection,
+  footer: FooterSection,
+};
+
+export default function ServiceDetail({ initialData }: { initialData: any }) {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      {initialData?.pages?.["service-detail"]?.sections?.map((section: any) => {
+        if (!section.enabled) {
+          return null;
+        }
+
+        const Renderer = sectionRenderers[section.type];
+        if (!Renderer) {
+          return null;
+        }
+
+        return <Renderer key={section.id} data={{ id: section.id, ...section.data }} />;
+      })}
+    </main>
+  );
+}

--- a/theme/components/sections/about-section.tsx
+++ b/theme/components/sections/about-section.tsx
@@ -1,0 +1,37 @@
+export type AboutSectionData = {
+  id?: string;
+  title: string;
+  description: string;
+  highlights: Array<{
+    title: string;
+    description: string;
+  }>;
+  imageSrc: string;
+  imageAlt: string;
+};
+
+export function AboutSection({ data }: { data: AboutSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-muted/20 py-16 text-foreground">
+      <div className="mx-auto grid max-w-6xl items-center gap-12 px-6 lg:grid-cols-2">
+        <div className="overflow-hidden rounded-3xl border border-border shadow-lg">
+          <img src={data.imageSrc} alt={data.imageAlt} className="h-full w-full object-cover" />
+        </div>
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{data.title}</h2>
+          <p className="mt-4 text-base text-muted-foreground">{data.description}</p>
+          <dl className="mt-8 space-y-6">
+            {data.highlights.map((highlight, index) => (
+              <div key={`${highlight.title}-${index}`} className="rounded-2xl border border-border bg-background p-6 shadow-sm">
+                <dt className="text-lg font-semibold text-foreground">{highlight.title}</dt>
+                <dd className="mt-2 text-sm text-muted-foreground">{highlight.description}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/blog-article-section.tsx
+++ b/theme/components/sections/blog-article-section.tsx
@@ -1,0 +1,37 @@
+export type BlogArticleSectionData = {
+  id?: string;
+  title: string;
+  author: string;
+  publishDate: string;
+  readingTime?: string;
+  featuredImageSrc?: string;
+  featuredImageAlt?: string;
+  content: string;
+};
+
+export function BlogArticleSection({ data }: { data: BlogArticleSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-background py-16 text-foreground">
+      <div className="mx-auto max-w-3xl px-6">
+        <header className="text-center">
+          <p className="text-xs uppercase tracking-wide text-primary">{data.publishDate}</p>
+          <h1 className="mt-3 text-4xl font-bold tracking-tight sm:text-5xl">{data.title}</h1>
+          <div className="mt-4 flex justify-center gap-3 text-xs text-muted-foreground">
+            <span className="font-semibold text-foreground">{data.author}</span>
+            {data.readingTime && <span>{data.readingTime}</span>}
+          </div>
+        </header>
+        {data.featuredImageSrc && data.featuredImageAlt && (
+          <div className="mt-10 overflow-hidden rounded-3xl border border-border shadow-lg">
+            <img src={data.featuredImageSrc} alt={data.featuredImageAlt} className="h-full w-full object-cover" />
+          </div>
+        )}
+        <div className="prose prose-lg mx-auto mt-10 max-w-none text-foreground prose-headings:text-foreground prose-a:text-primary">
+          <div dangerouslySetInnerHTML={{ __html: data.content }} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/blog-list-section.tsx
+++ b/theme/components/sections/blog-list-section.tsx
@@ -1,0 +1,47 @@
+export type BlogListSectionData = {
+  id?: string;
+  title: string;
+  description?: string;
+  posts: Array<{
+    title: string;
+    excerpt: string;
+    href: string;
+    author: string;
+    publishDate: string;
+    readingTime?: string;
+  }>;
+};
+
+export function BlogListSection({ data }: { data: BlogListSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-background py-16 text-foreground">
+      <div className="mx-auto max-w-4xl px-6">
+        <div className="text-center">
+          <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">{data.title}</h1>
+          {data.description && (
+            <p className="mt-4 text-base text-muted-foreground">{data.description}</p>
+          )}
+        </div>
+        <div className="mt-12 space-y-10">
+          {data.posts.map((post) => (
+            <article key={post.href} className="rounded-3xl border border-border bg-muted/10 p-8 shadow-sm">
+              <div className="text-xs uppercase tracking-wide text-primary">{post.publishDate}</div>
+              <h2 className="mt-3 text-2xl font-semibold text-foreground">
+                <a href={post.href} className="transition-colors hover:text-primary">
+                  {post.title}
+                </a>
+              </h2>
+              <p className="mt-3 text-sm text-muted-foreground">{post.excerpt}</p>
+              <div className="mt-6 flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+                <span className="font-semibold text-foreground">{post.author}</span>
+                {post.readingTime && <span>{post.readingTime}</span>}
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/blog-teaser-section.tsx
+++ b/theme/components/sections/blog-teaser-section.tsx
@@ -1,0 +1,61 @@
+export type BlogTeaserSectionData = {
+  id?: string;
+  title: string;
+  description?: string;
+  viewAllLabel: string;
+  viewAllHref: string;
+  posts: Array<{
+    title: string;
+    excerpt: string;
+    href: string;
+    author: string;
+    publishDate: string;
+    ctaLabel: string;
+    imageSrc?: string;
+    imageAlt?: string;
+  }>;
+};
+
+export function BlogTeaserSection({ data }: { data: BlogTeaserSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-muted/10 py-20 text-foreground">
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{data.title}</h2>
+            {data.description && (
+              <p className="mt-2 text-base text-muted-foreground">{data.description}</p>
+            )}
+          </div>
+          <a href={data.viewAllHref} className="text-sm font-semibold text-primary transition-colors hover:text-primary/80">
+            {data.viewAllLabel}
+          </a>
+        </div>
+        <div className="mt-10 grid gap-6 lg:grid-cols-3">
+          {data.posts.map((post) => (
+            <article key={post.href} className="flex h-full flex-col rounded-3xl border border-border bg-background p-6 shadow-sm">
+              {post.imageSrc && post.imageAlt && (
+                <img src={post.imageSrc} alt={post.imageAlt} className="h-40 w-full rounded-2xl object-cover" />
+              )}
+              <div className="mt-4 flex-1">
+                <h3 className="text-lg font-semibold text-foreground">{post.title}</h3>
+                <p className="mt-2 text-sm text-muted-foreground">{post.excerpt}</p>
+              </div>
+              <div className="mt-4 text-xs text-muted-foreground">
+                <span className="font-semibold text-foreground">{post.author}</span> · {post.publishDate}
+              </div>
+              <a
+                href={post.href}
+                className="mt-4 inline-flex items-center text-sm font-semibold text-primary transition-colors hover:text-primary/80"
+              >
+                {post.ctaLabel}
+              </a>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/contact-section.tsx
+++ b/theme/components/sections/contact-section.tsx
@@ -1,0 +1,53 @@
+export type ContactSectionData = {
+  id?: string;
+  title: string;
+  description: string;
+  contactMethods: Array<{
+    label: string;
+    value: string;
+    href: string;
+  }>;
+  cardTitle: string;
+  cardDescription: string;
+  formCtaLabel?: string;
+  formCtaHref?: string;
+};
+
+export function ContactSection({ data }: { data: ContactSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-background py-20 text-foreground">
+      <div className="mx-auto grid max-w-6xl gap-10 px-6 lg:grid-cols-2 lg:items-center">
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{data.title}</h2>
+          <p className="mt-4 text-base text-muted-foreground">{data.description}</p>
+          <dl className="mt-8 space-y-4">
+            {data.contactMethods.map((method) => (
+              <div key={method.label} className="flex flex-col rounded-2xl border border-border bg-muted/10 p-6 shadow-sm">
+                <dt className="text-sm font-semibold text-muted-foreground">{method.label}</dt>
+                <dd className="mt-1 text-lg font-semibold text-foreground">
+                  <a href={method.href} className="transition-colors hover:text-primary">
+                    {method.value}
+                  </a>
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+        <div className="rounded-3xl border border-border bg-muted/10 p-10 shadow-sm">
+          <div className="text-lg font-semibold text-foreground">{data.cardTitle}</div>
+          <p className="mt-2 text-sm text-muted-foreground">{data.cardDescription}</p>
+          {data.formCtaLabel && data.formCtaHref && (
+            <a
+              href={data.formCtaHref}
+              className="mt-6 inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+              {data.formCtaLabel}
+            </a>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/features-section.tsx
+++ b/theme/components/sections/features-section.tsx
@@ -1,0 +1,49 @@
+export type FeaturesSectionData = {
+  id?: string;
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  items: Array<{
+    icon?: string;
+    title: string;
+    description: string;
+  }>;
+};
+
+export function FeaturesSection({ data }: { data: FeaturesSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-background py-16 text-foreground">
+      <div className="mx-auto max-w-6xl px-6">
+        {data.eyebrow && (
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">{data.eyebrow}</p>
+        )}
+        <div className="mt-4 grid gap-10 lg:grid-cols-[1fr,1.2fr]">
+          <div>
+            <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{data.title}</h2>
+            {data.description && (
+              <p className="mt-4 text-base text-muted-foreground">{data.description}</p>
+            )}
+          </div>
+          <div className="grid gap-6 sm:grid-cols-2">
+            {data.items.map((item, index) => (
+              <div
+                key={`${item.title}-${index}`}
+                className="flex h-full flex-col rounded-2xl border border-border bg-muted/10 p-6 shadow-sm"
+              >
+                {item.icon && (
+                  <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+                    <img src={item.icon} alt={item.title} className="h-6 w-6" />
+                  </div>
+                )}
+                <h3 className="text-lg font-semibold text-foreground">{item.title}</h3>
+                <p className="mt-2 text-sm text-muted-foreground">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/footer-section.tsx
+++ b/theme/components/sections/footer-section.tsx
@@ -1,0 +1,72 @@
+export type FooterSectionData = {
+  id?: string;
+  logoSrc: string;
+  logoAlt: string;
+  description: string;
+  navigationGroups: Array<{
+    title: string;
+    links: Array<{
+      label: string;
+      href: string;
+    }>;
+  }>;
+  contactInfo: Array<{
+    label: string;
+    value: string;
+    href?: string;
+  }>;
+  copyright: string;
+};
+
+export function FooterSection({ data }: { data: FooterSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-foreground text-foreground">
+      <footer className="mx-auto max-w-6xl px-6 py-16 text-background">
+        <div className="grid gap-10 lg:grid-cols-[1.2fr,2fr]">
+          <div className="space-y-6">
+            <div className="flex items-center gap-3">
+              <span className="flex h-12 w-12 items-center justify-center rounded-full bg-background/10">
+                <img src={data.logoSrc} alt={data.logoAlt} className="h-7 w-7 object-contain" />
+              </span>
+              <p className="text-lg font-semibold text-background">{data.description}</p>
+            </div>
+            <ul className="space-y-2 text-sm text-background/70">
+              {data.contactInfo.map((item) => (
+                <li key={item.label}>
+                  {item.href ? (
+                    <a href={item.href} className="transition-colors hover:text-background">
+                      <span className="font-semibold text-background">{item.label}:</span> {item.value}
+                    </a>
+                  ) : (
+                    <span>
+                      <span className="font-semibold text-background">{item.label}:</span> {item.value}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            {data.navigationGroups.map((group) => (
+              <div key={group.title}>
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-background/70">{group.title}</h3>
+                <ul className="mt-4 space-y-2 text-sm text-background/70">
+                  {group.links.map((link) => (
+                    <li key={link.href}>
+                      <a href={link.href} className="transition-colors hover:text-background">
+                        {link.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="mt-12 border-t border-background/10 pt-6 text-xs text-background/60">{data.copyright}</div>
+      </footer>
+    </section>
+  );
+}

--- a/theme/components/sections/header-section.tsx
+++ b/theme/components/sections/header-section.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+
+export type HeaderSectionData = {
+  id?: string;
+  logoSrc: string;
+  logoAlt: string;
+  brandName: string;
+  navigation: Array<{
+    label: string;
+    href: string;
+  }>;
+  ctaButtons: Array<{
+    label: string;
+    href: string;
+    style?: "primary" | "secondary";
+  }>;
+};
+
+export function HeaderSection({ data }: { data: HeaderSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section
+      id={sectionId}
+      className="bg-background text-foreground border-b border-border"
+      aria-label="Primary navigation"
+    >
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-6 px-6 py-4">
+        <div className="flex items-center gap-3">
+          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+            <img src={data.logoSrc} alt={data.logoAlt} className="h-6 w-6 object-contain" />
+          </span>
+          <span className="text-lg font-semibold text-foreground">{data.brandName}</span>
+        </div>
+        <nav className="hidden items-center gap-6 text-sm font-medium text-muted-foreground md:flex">
+          {data.navigation.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="transition-colors hover:text-foreground"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="hidden items-center gap-3 md:flex">
+          {data.ctaButtons.map((button) => (
+            <Link
+              key={button.href}
+              href={button.href}
+              className={
+                button.style === "secondary"
+                  ? "rounded-full border border-border px-5 py-2 text-sm font-semibold text-foreground transition-colors hover:border-primary hover:text-primary"
+                  : "rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+              }
+            >
+              {button.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/hero-section.tsx
+++ b/theme/components/sections/hero-section.tsx
@@ -1,0 +1,82 @@
+export type HeroSectionData = {
+  id?: string;
+  eyebrow: string;
+  title: string;
+  description: string;
+  primaryCtaLabel: string;
+  primaryCtaHref: string;
+  secondaryCtaLabel?: string;
+  secondaryCtaHref?: string;
+  stats: Array<{
+    label: string;
+    value: string;
+  }>;
+  imageSrc: string;
+  imageAlt: string;
+  partnerLogos?: Array<{
+    src: string;
+    alt: string;
+  }>;
+};
+
+export function HeroSection({ data }: { data: HeroSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-background text-foreground">
+      <div className="mx-auto flex max-w-6xl flex-col gap-12 px-6 pb-16 pt-12 lg:flex-row lg:items-center lg:gap-16">
+        <div className="flex-1">
+          <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-sm font-semibold text-primary">
+            {data.eyebrow}
+          </span>
+          <h1 className="mt-6 text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+            {data.title}
+          </h1>
+          <p className="mt-4 max-w-xl text-lg text-muted-foreground">{data.description}</p>
+          <div className="mt-8 flex flex-wrap items-center gap-4">
+            <a
+              href={data.primaryCtaHref}
+              className="rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+            >
+              {data.primaryCtaLabel}
+            </a>
+            {data.secondaryCtaLabel && data.secondaryCtaHref && (
+              <a
+                href={data.secondaryCtaHref}
+                className="rounded-full border border-border px-6 py-3 text-sm font-semibold text-foreground transition-colors hover:border-primary hover:text-primary"
+              >
+                {data.secondaryCtaLabel}
+              </a>
+            )}
+          </div>
+          {data.stats.length > 0 && (
+            <dl className="mt-10 grid grid-cols-1 gap-6 sm:grid-cols-3">
+              {data.stats.map((stat) => (
+                <div key={stat.label} className="rounded-2xl border border-border p-6 shadow-sm">
+                  <dt className="text-sm font-semibold text-muted-foreground">{stat.label}</dt>
+                  <dd className="mt-2 text-2xl font-bold text-foreground">{stat.value}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+        </div>
+        <div className="flex flex-1 flex-col gap-6">
+          <div className="overflow-hidden rounded-3xl border border-border bg-muted/20 p-4 shadow-lg">
+            <img
+              src={data.imageSrc}
+              alt={data.imageAlt}
+              className="h-full w-full rounded-2xl object-cover"
+            />
+          </div>
+          {data.partnerLogos && data.partnerLogos.length > 0 && (
+            <div className="flex items-center justify-around gap-6 rounded-2xl border border-dashed border-border px-6 py-4">
+              {data.partnerLogos.map((logo) => (
+                <img key={logo.src} src={logo.src} alt={logo.alt} className="h-8 w-auto opacity-70" />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/pricing-section.tsx
+++ b/theme/components/sections/pricing-section.tsx
@@ -1,0 +1,63 @@
+export type PricingSectionData = {
+  id?: string;
+  title: string;
+  description: string;
+  plans: Array<{
+    name: string;
+    price: string;
+    billingNote?: string;
+    features: Array<{
+      value: string;
+    }>;
+    ctaLabel: string;
+    ctaHref: string;
+    highlighted?: boolean;
+  }>;
+};
+
+export function PricingSection({ data }: { data: PricingSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-primary text-primary-foreground py-20">
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{data.title}</h2>
+          <p className="mt-4 text-base text-primary-foreground/80">{data.description}</p>
+        </div>
+        <div className="mt-12 grid gap-6 lg:grid-cols-3">
+          {data.plans.map((plan) => (
+            <div
+              key={plan.name}
+              className={`flex h-full flex-col rounded-3xl border border-primary-foreground/20 bg-primary/10 p-8 text-left shadow-lg ${
+                plan.highlighted ? "ring-2 ring-primary-foreground" : ""
+              }`}
+            >
+              <div>
+                <h3 className="text-xl font-semibold">{plan.name}</h3>
+                <p className="mt-2 text-4xl font-bold">{plan.price}</p>
+                {plan.billingNote && (
+                  <p className="mt-1 text-sm text-primary-foreground/70">{plan.billingNote}</p>
+                )}
+                <ul className="mt-6 space-y-3 text-sm text-primary-foreground/80">
+                  {plan.features.map((feature, index) => (
+                    <li key={`${plan.name}-feature-${index}`} className="flex items-start gap-2">
+                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary-foreground" />
+                      <span>{feature.value}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <a
+                href={plan.ctaHref}
+                className="mt-8 inline-flex items-center justify-center rounded-full bg-primary-foreground px-6 py-3 text-sm font-semibold text-primary transition-transform hover:scale-[1.02]"
+              >
+                {plan.ctaLabel}
+              </a>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/process-section.tsx
+++ b/theme/components/sections/process-section.tsx
@@ -1,0 +1,44 @@
+export type ProcessSectionData = {
+  id?: string;
+  title: string;
+  description: string;
+  steps: Array<{
+    title: string;
+    description: string;
+  }>;
+  imageSrc?: string;
+  imageAlt?: string;
+};
+
+export function ProcessSection({ data }: { data: ProcessSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-muted/10 py-16 text-foreground">
+      <div className="mx-auto grid max-w-6xl gap-12 px-6 lg:grid-cols-[1.1fr,0.9fr] lg:items-center">
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{data.title}</h2>
+          <p className="mt-4 text-base text-muted-foreground">{data.description}</p>
+          <ol className="mt-8 space-y-6">
+            {data.steps.map((step, index) => (
+              <li key={step.title} className="flex gap-4">
+                <span className="flex h-10 w-10 flex-none items-center justify-center rounded-full bg-primary/10 text-base font-semibold text-primary">
+                  {index + 1}
+                </span>
+                <div className="rounded-2xl border border-border bg-background p-6 shadow-sm">
+                  <h3 className="text-lg font-semibold text-foreground">{step.title}</h3>
+                  <p className="mt-2 text-sm text-muted-foreground">{step.description}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+        {data.imageSrc && data.imageAlt && (
+          <div className="overflow-hidden rounded-3xl border border-border shadow-lg">
+            <img src={data.imageSrc} alt={data.imageAlt} className="h-full w-full object-cover" />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/service-contact-section.tsx
+++ b/theme/components/sections/service-contact-section.tsx
@@ -1,0 +1,47 @@
+export type ServiceContactSectionData = {
+  id?: string;
+  title: string;
+  description: string;
+  ctaLabel: string;
+  ctaHref: string;
+  supportDetails: Array<{
+    label: string;
+    value: string;
+    href?: string;
+  }>;
+};
+
+export function ServiceContactSection({ data }: { data: ServiceContactSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-primary py-16 text-primary-foreground">
+      <div className="mx-auto max-w-4xl px-6 text-center">
+        <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{data.title}</h2>
+        <p className="mt-4 text-base text-primary-foreground/80">{data.description}</p>
+        <a
+          href={data.ctaHref}
+          className="mt-8 inline-flex items-center justify-center rounded-full bg-primary-foreground px-6 py-3 text-sm font-semibold text-primary transition-transform hover:scale-[1.02]"
+        >
+          {data.ctaLabel}
+        </a>
+        <div className="mt-10 grid gap-4 sm:grid-cols-3">
+          {data.supportDetails.map((detail) => (
+            <div key={detail.label} className="rounded-2xl border border-primary-foreground/20 bg-primary/20 p-6">
+              <div className="text-xs font-semibold uppercase tracking-wide text-primary-foreground/70">{detail.label}</div>
+              <div className="mt-2 text-sm font-semibold text-primary-foreground">
+                {detail.href ? (
+                  <a href={detail.href} className="transition-colors hover:text-primary-foreground/70">
+                    {detail.value}
+                  </a>
+                ) : (
+                  detail.value
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/service-description-section.tsx
+++ b/theme/components/sections/service-description-section.tsx
@@ -1,0 +1,30 @@
+export type ServiceDescriptionSectionData = {
+  id?: string;
+  title: string;
+  overview: string;
+  benefits: Array<{
+    title: string;
+    description: string;
+  }>;
+};
+
+export function ServiceDescriptionSection({ data }: { data: ServiceDescriptionSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-background py-16 text-foreground">
+      <div className="mx-auto max-w-5xl px-6">
+        <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{data.title}</h2>
+        <p className="mt-4 text-base text-muted-foreground">{data.overview}</p>
+        <div className="mt-10 grid gap-6 sm:grid-cols-2">
+          {data.benefits.map((benefit) => (
+            <div key={benefit.title} className="rounded-3xl border border-border bg-muted/10 p-6 shadow-sm">
+              <h3 className="text-lg font-semibold text-foreground">{benefit.title}</h3>
+              <p className="mt-2 text-sm text-muted-foreground">{benefit.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/service-hero-section.tsx
+++ b/theme/components/sections/service-hero-section.tsx
@@ -1,0 +1,41 @@
+export type ServiceHeroSectionData = {
+  id?: string;
+  eyebrow?: string;
+  title: string;
+  description: string;
+  imageSrc?: string;
+  imageAlt?: string;
+  ctaLabel?: string;
+  ctaHref?: string;
+};
+
+export function ServiceHeroSection({ data }: { data: ServiceHeroSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-muted/10 py-16 text-foreground">
+      <div className="mx-auto grid max-w-5xl gap-10 px-6 lg:grid-cols-[1.2fr,0.8fr] lg:items-center">
+        <div>
+          {data.eyebrow && (
+            <p className="text-sm font-semibold uppercase tracking-wide text-primary">{data.eyebrow}</p>
+          )}
+          <h1 className="mt-4 text-4xl font-bold tracking-tight sm:text-5xl">{data.title}</h1>
+          <p className="mt-4 text-base text-muted-foreground">{data.description}</p>
+          {data.ctaLabel && data.ctaHref && (
+            <a
+              href={data.ctaHref}
+              className="mt-6 inline-flex items-center rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+              {data.ctaLabel}
+            </a>
+          )}
+        </div>
+        {data.imageSrc && data.imageAlt && (
+          <div className="overflow-hidden rounded-3xl border border-border bg-background shadow-lg">
+            <img src={data.imageSrc} alt={data.imageAlt} className="h-full w-full object-cover" />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/service-pricing-section.tsx
+++ b/theme/components/sections/service-pricing-section.tsx
@@ -1,0 +1,51 @@
+export type ServicePricingSectionData = {
+  id?: string;
+  title: string;
+  description: string;
+  tiers: Array<{
+    name: string;
+    price: string;
+    features: string[];
+    ctaLabel: string;
+    ctaHref: string;
+  }>;
+};
+
+export function ServicePricingSection({ data }: { data: ServicePricingSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-muted/10 py-16 text-foreground">
+      <div className="mx-auto max-w-5xl px-6">
+        <div className="text-center">
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{data.title}</h2>
+          <p className="mt-4 text-base text-muted-foreground">{data.description}</p>
+        </div>
+        <div className="mt-10 grid gap-6 md:grid-cols-3">
+          {data.tiers.map((tier) => (
+            <div key={tier.name} className="flex h-full flex-col rounded-3xl border border-border bg-background p-6 shadow-sm">
+              <div>
+                <h3 className="text-lg font-semibold text-foreground">{tier.name}</h3>
+                <p className="mt-2 text-3xl font-bold text-foreground">{tier.price}</p>
+                <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
+                  {tier.features.map((feature) => (
+                    <li key={feature} className="flex items-start gap-2">
+                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" />
+                      <span>{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <a
+                href={tier.ctaHref}
+                className="mt-6 inline-flex items-center justify-center rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                {tier.ctaLabel}
+              </a>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/services-section.tsx
+++ b/theme/components/sections/services-section.tsx
@@ -1,0 +1,56 @@
+export type ServicesSectionData = {
+  id?: string;
+  title: string;
+  description: string;
+  services: Array<{
+    name: string;
+    summary: string;
+    href: string;
+    features: Array<{
+      value: string;
+    }>;
+  }>;
+  ctaLabel?: string;
+};
+
+export function ServicesSection({ data }: { data: ServicesSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-background py-16 text-foreground">
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{data.title}</h2>
+          <p className="mt-4 text-base text-muted-foreground">{data.description}</p>
+        </div>
+        <div className="mt-12 grid gap-6 lg:grid-cols-3">
+          {data.services.map((service) => (
+            <div
+              key={service.name}
+              className="flex h-full flex-col justify-between rounded-2xl border border-border bg-muted/10 p-6 shadow-sm"
+            >
+              <div>
+                <h3 className="text-xl font-semibold text-foreground">{service.name}</h3>
+                <p className="mt-3 text-sm text-muted-foreground">{service.summary}</p>
+                <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
+                  {service.features.map((feature, index) => (
+                    <li key={`${service.name}-feature-${index}`} className="flex items-start gap-2">
+                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" />
+                      <span>{feature.value}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <a
+                href={service.href}
+                className="mt-6 inline-flex items-center text-sm font-semibold text-primary transition-colors hover:text-primary/80"
+              >
+                {data.ctaLabel ?? "Learn more"}
+              </a>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/team-section.tsx
+++ b/theme/components/sections/team-section.tsx
@@ -1,0 +1,60 @@
+export type TeamSectionData = {
+  id?: string;
+  title: string;
+  description?: string;
+  members: Array<{
+    name: string;
+    role: string;
+    bio?: string;
+    imageSrc?: string;
+    imageAlt?: string;
+    socialLinks?: Array<{
+      label: string;
+      href: string;
+    }>;
+  }>;
+};
+
+export function TeamSection({ data }: { data: TeamSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-muted/20 py-20 text-foreground">
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{data.title}</h2>
+          {data.description && (
+            <p className="mt-4 text-base text-muted-foreground">{data.description}</p>
+          )}
+        </div>
+        <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {data.members.map((member) => (
+            <div key={member.name} className="flex h-full flex-col rounded-3xl border border-border bg-background p-6 shadow-sm">
+              {member.imageSrc && member.imageAlt && (
+                <img
+                  src={member.imageSrc}
+                  alt={member.imageAlt}
+                  className="h-40 w-full rounded-2xl object-cover"
+                />
+              )}
+              <div className="mt-4">
+                <h3 className="text-lg font-semibold text-foreground">{member.name}</h3>
+                <p className="text-sm text-primary">{member.role}</p>
+                {member.bio && <p className="mt-2 text-sm text-muted-foreground">{member.bio}</p>}
+              </div>
+              {member.socialLinks && member.socialLinks.length > 0 && (
+                <div className="mt-4 flex flex-wrap gap-3 text-xs font-semibold text-primary">
+                  {member.socialLinks.map((link) => (
+                    <a key={link.href} href={link.href} className="transition-colors hover:text-primary/70">
+                      {link.label}
+                    </a>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/components/sections/testimonials-section.tsx
+++ b/theme/components/sections/testimonials-section.tsx
@@ -1,0 +1,54 @@
+export type TestimonialsSectionData = {
+  id?: string;
+  title: string;
+  description?: string;
+  testimonials: Array<{
+    quote: string;
+    author: string;
+    role?: string;
+    avatarSrc?: string;
+    avatarAlt?: string;
+  }>;
+};
+
+export function TestimonialsSection({ data }: { data: TestimonialsSectionData }) {
+  const sectionId = data.id ? `section-${data.id}` : undefined;
+
+  return (
+    <section id={sectionId} className="bg-background py-20 text-foreground">
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{data.title}</h2>
+          {data.description && (
+            <p className="mt-4 text-base text-muted-foreground">{data.description}</p>
+          )}
+        </div>
+        <div className="mt-12 grid gap-6 lg:grid-cols-3">
+          {data.testimonials.map((testimonial, index) => (
+            <figure
+              key={`${testimonial.author}-${index}`}
+              className="flex h-full flex-col justify-between rounded-3xl border border-border bg-muted/10 p-8 shadow-sm"
+            >
+              <blockquote className="text-base text-muted-foreground">“{testimonial.quote}”</blockquote>
+              <figcaption className="mt-6 flex items-center gap-4">
+                {testimonial.avatarSrc && testimonial.avatarAlt && (
+                  <img
+                    src={testimonial.avatarSrc}
+                    alt={testimonial.avatarAlt}
+                    className="h-12 w-12 rounded-full object-cover"
+                  />
+                )}
+                <div>
+                  <div className="text-sm font-semibold text-foreground">{testimonial.author}</div>
+                  {testimonial.role && (
+                    <div className="text-xs text-muted-foreground">{testimonial.role}</div>
+                  )}
+                </div>
+              </figcaption>
+            </figure>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/theme/provisional-site-schema.ts
+++ b/theme/provisional-site-schema.ts
@@ -1,0 +1,572 @@
+export const siteSchema = {
+  _meta: { schemaVersion: 1 },
+  sectionTypes: {
+    header: {
+      displayName: "Header",
+      schema: {
+        logoSrc: { type: "image", editable: true },
+        logoAlt: { type: "string", editable: true, maxLength: 80 },
+        brandName: { type: "string", editable: true, maxLength: 80 },
+        navigation: {
+          type: "array",
+          itemSchema: {
+            label: { type: "string", editable: true, maxLength: 40 },
+            href: { type: "string", editable: true, maxLength: 120 },
+          },
+        },
+        ctaButtons: {
+          type: "array",
+          itemSchema: {
+            label: { type: "string", editable: true, maxLength: 30 },
+            href: { type: "string", editable: true, maxLength: 120 },
+            style: {
+              type: "select",
+              editable: true,
+              options: [
+                { label: "Primary", value: "primary" },
+                { label: "Secondary", value: "secondary" },
+              ],
+            },
+          },
+        },
+      },
+      defaultData: {
+        logoSrc: "/logo.svg",
+        logoAlt: "Company logo",
+        brandName: "Compass",
+        navigation: [],
+        ctaButtons: [],
+      },
+    },
+    hero: {
+      displayName: "Hero",
+      schema: {
+        eyebrow: { type: "string", editable: true, maxLength: 80 },
+        title: { type: "string", editable: true, maxLength: 120 },
+        description: { type: "string", editable: true, maxLength: 200 },
+        primaryCtaLabel: { type: "string", editable: true, maxLength: 40 },
+        primaryCtaHref: { type: "string", editable: true, maxLength: 120 },
+        secondaryCtaLabel: { type: "string", editable: true, maxLength: 40 },
+        secondaryCtaHref: { type: "string", editable: true, maxLength: 120 },
+        stats: {
+          type: "array",
+          itemSchema: {
+            label: { type: "string", editable: true, maxLength: 60 },
+            value: { type: "string", editable: true, maxLength: 40 },
+          },
+        },
+        imageSrc: { type: "image", editable: true },
+        imageAlt: { type: "string", editable: true, maxLength: 120 },
+        partnerLogos: {
+          type: "array",
+          itemSchema: {
+            src: { type: "image", editable: true },
+            alt: { type: "string", editable: true, maxLength: 80 },
+          },
+        },
+      },
+      defaultData: {
+        eyebrow: "Streamlined accounting",
+        title: "Accounting support tailored to your growth",
+        description: "Modern bookkeeping, tax strategy, and advisory designed for ambitious teams.",
+        primaryCtaLabel: "Schedule a call",
+        primaryCtaHref: "/contact",
+        secondaryCtaLabel: "See pricing",
+        secondaryCtaHref: "/pricing",
+        stats: [],
+        imageSrc: "/images/hero.jpg",
+        imageAlt: "Accounting team collaborating",
+        partnerLogos: [],
+      },
+    },
+    aboutUsHero: {
+      displayName: "About Hero",
+      schema: {
+        eyebrow: { type: "string", editable: true, maxLength: 80 },
+        title: { type: "string", editable: true, maxLength: 140 },
+        description: { type: "string", editable: true, maxLength: 220 },
+        primaryCtaLabel: { type: "string", editable: true, maxLength: 40 },
+        primaryCtaHref: { type: "string", editable: true, maxLength: 120 },
+        secondaryCtaLabel: { type: "string", editable: true, maxLength: 40 },
+        secondaryCtaHref: { type: "string", editable: true, maxLength: 120 },
+        stats: {
+          type: "array",
+          itemSchema: {
+            label: { type: "string", editable: true, maxLength: 60 },
+            value: { type: "string", editable: true, maxLength: 40 },
+          },
+        },
+        imageSrc: { type: "image", editable: true },
+        imageAlt: { type: "string", editable: true, maxLength: 120 },
+        partnerLogos: {
+          type: "array",
+          itemSchema: {
+            src: { type: "image", editable: true },
+            alt: { type: "string", editable: true, maxLength: 80 },
+          },
+        },
+      },
+      defaultData: {
+        eyebrow: "About",
+        title: "Purpose-built for accounting leaders",
+        description: "Share your origin story and impact with prospects and clients.",
+        primaryCtaLabel: "Connect with us",
+        primaryCtaHref: "/contact",
+        secondaryCtaLabel: "Our services",
+        secondaryCtaHref: "/services",
+        stats: [],
+        imageSrc: "/images/about-hero.jpg",
+        imageAlt: "Team collaborating",
+        partnerLogos: [],
+      },
+    },
+    features: {
+      displayName: "Features",
+      schema: {
+        eyebrow: { type: "string", editable: true, maxLength: 60 },
+        title: { type: "string", editable: true, maxLength: 120 },
+        description: { type: "string", editable: true, maxLength: 220 },
+        items: {
+          type: "array",
+          itemSchema: {
+            icon: { type: "image", editable: true },
+            title: { type: "string", editable: true, maxLength: 80 },
+            description: { type: "string", editable: true, maxLength: 200 },
+          },
+        },
+      },
+      defaultData: {
+        eyebrow: "Capabilities",
+        title: "Streamlined solutions for every finance team",
+        description: "Comprehensive services that scale with your business as it grows.",
+        items: [],
+      },
+    },
+    services: {
+      displayName: "Services",
+      schema: {
+        title: { type: "string", editable: true, maxLength: 120 },
+        description: { type: "string", editable: true, maxLength: 220 },
+        ctaLabel: { type: "string", editable: true, maxLength: 40 },
+        services: {
+          type: "array",
+          itemSchema: {
+            name: { type: "string", editable: true, maxLength: 80 },
+            summary: { type: "string", editable: true, maxLength: 200 },
+            href: { type: "string", editable: true, maxLength: 120 },
+            features: {
+              type: "array",
+              itemSchema: {
+                value: { type: "string", editable: true, maxLength: 120 },
+              },
+            },
+          },
+        },
+      },
+      defaultData: {
+        title: "Services tailored to your needs",
+        description: "Choose the support level that fits your stage and industry.",
+        ctaLabel: "Learn more",
+        services: [],
+      },
+    },
+    process: {
+      displayName: "Process",
+      schema: {
+        title: { type: "string", editable: true, maxLength: 120 },
+        description: { type: "string", editable: true, maxLength: 220 },
+        steps: {
+          type: "array",
+          itemSchema: {
+            title: { type: "string", editable: true, maxLength: 80 },
+            description: { type: "string", editable: true, maxLength: 200 },
+          },
+        },
+        imageSrc: { type: "image", editable: true },
+        imageAlt: { type: "string", editable: true, maxLength: 120 },
+      },
+      defaultData: {
+        title: "How we collaborate",
+        description: "A proven onboarding approach that removes friction from your finance operations.",
+        steps: [],
+        imageSrc: "/images/process.jpg",
+        imageAlt: "Team meeting",
+      },
+    },
+    pricing: {
+      displayName: "Pricing",
+      schema: {
+        title: { type: "string", editable: true, maxLength: 120 },
+        description: { type: "string", editable: true, maxLength: 220 },
+        plans: {
+          type: "array",
+          itemSchema: {
+            name: { type: "string", editable: true, maxLength: 60 },
+            price: { type: "string", editable: true, maxLength: 40 },
+            billingNote: { type: "string", editable: true, maxLength: 80 },
+            features: {
+              type: "array",
+              itemSchema: {
+                value: { type: "string", editable: true, maxLength: 120 },
+              },
+            },
+            ctaLabel: { type: "string", editable: true, maxLength: 40 },
+            ctaHref: { type: "string", editable: true, maxLength: 120 },
+            highlighted: { type: "boolean", editable: true },
+          },
+        },
+      },
+      defaultData: {
+        title: "Flexible plans",
+        description: "Transparent pricing aligned with your growth goals.",
+        plans: [],
+      },
+    },
+    testimonials: {
+      displayName: "Testimonials",
+      schema: {
+        title: { type: "string", editable: true, maxLength: 120 },
+        description: { type: "string", editable: true, maxLength: 220 },
+        testimonials: {
+          type: "array",
+          itemSchema: {
+            quote: { type: "string", editable: true, maxLength: 260 },
+            author: { type: "string", editable: true, maxLength: 80 },
+            role: { type: "string", editable: true, maxLength: 80 },
+            avatarSrc: { type: "image", editable: true },
+            avatarAlt: { type: "string", editable: true, maxLength: 80 },
+          },
+        },
+      },
+      defaultData: {
+        title: "Clients love us",
+        description: "Hear from the teams who trust Compass with their finances.",
+        testimonials: [],
+      },
+    },
+    about: {
+      displayName: "About",
+      schema: {
+        title: { type: "string", editable: true, maxLength: 120 },
+        description: { type: "string", editable: true, maxLength: 220 },
+        highlights: {
+          type: "array",
+          itemSchema: {
+            title: { type: "string", editable: true, maxLength: 80 },
+            description: { type: "string", editable: true, maxLength: 200 },
+          },
+        },
+        imageSrc: { type: "image", editable: true },
+        imageAlt: { type: "string", editable: true, maxLength: 120 },
+      },
+      defaultData: {
+        title: "Who we are",
+        description: "Dedicated specialists with a passion for simplifying accounting.",
+        highlights: [],
+        imageSrc: "/images/about.jpg",
+        imageAlt: "Team portrait",
+      },
+    },
+    team: {
+      displayName: "Team",
+      schema: {
+        title: { type: "string", editable: true, maxLength: 120 },
+        description: { type: "string", editable: true, maxLength: 220 },
+        members: {
+          type: "array",
+          itemSchema: {
+            name: { type: "string", editable: true, maxLength: 80 },
+            role: { type: "string", editable: true, maxLength: 80 },
+            bio: { type: "string", editable: true, maxLength: 220 },
+            imageSrc: { type: "image", editable: true },
+            imageAlt: { type: "string", editable: true, maxLength: 120 },
+            socialLinks: {
+              type: "array",
+              itemSchema: {
+                label: { type: "string", editable: true, maxLength: 40 },
+                href: { type: "string", editable: true, maxLength: 120 },
+              },
+            },
+          },
+        },
+      },
+      defaultData: {
+        title: "Meet the leadership",
+        description: "Experts with decades of accounting experience.",
+        members: [],
+      },
+    },
+    contact: {
+      displayName: "Contact",
+      schema: {
+        title: { type: "string", editable: true, maxLength: 120 },
+        description: { type: "string", editable: true, maxLength: 220 },
+        contactMethods: {
+          type: "array",
+          itemSchema: {
+            label: { type: "string", editable: true, maxLength: 60 },
+            value: { type: "string", editable: true, maxLength: 120 },
+            href: { type: "string", editable: true, maxLength: 120 },
+          },
+        },
+        cardTitle: { type: "string", editable: true, maxLength: 120 },
+        cardDescription: { type: "string", editable: true, maxLength: 200 },
+        formCtaLabel: { type: "string", editable: true, maxLength: 40 },
+        formCtaHref: { type: "string", editable: true, maxLength: 120 },
+      },
+      defaultData: {
+        title: "Let’s work together",
+        description: "Share a few details and our advisors will respond within one day.",
+        contactMethods: [],
+        cardTitle: "Get a tailored proposal",
+        cardDescription: "Tell us about your team and goals so we can personalize your plan.",
+        formCtaLabel: "Start the conversation",
+        formCtaHref: "/contact",
+      },
+    },
+    footer: {
+      displayName: "Footer",
+      schema: {
+        logoSrc: { type: "image", editable: true },
+        logoAlt: { type: "string", editable: true, maxLength: 80 },
+        description: { type: "string", editable: true, maxLength: 160 },
+        navigationGroups: {
+          type: "array",
+          itemSchema: {
+            title: { type: "string", editable: true, maxLength: 60 },
+            links: {
+              type: "array",
+              itemSchema: {
+                label: { type: "string", editable: true, maxLength: 60 },
+                href: { type: "string", editable: true, maxLength: 120 },
+              },
+            },
+          },
+        },
+        contactInfo: {
+          type: "array",
+          itemSchema: {
+            label: { type: "string", editable: true, maxLength: 60 },
+            value: { type: "string", editable: true, maxLength: 120 },
+            href: { type: "string", editable: true, maxLength: 120 },
+          },
+        },
+        copyright: { type: "string", editable: true, maxLength: 120 },
+      },
+      defaultData: {
+        logoSrc: "/logo.svg",
+        logoAlt: "Compass logo",
+        description: "Streamlined accounting for modern teams.",
+        navigationGroups: [],
+        contactInfo: [],
+        copyright: "© 2024 Compass Accounting. All rights reserved.",
+      },
+    },
+    blogTeaser: {
+      displayName: "Blog Teaser",
+      schema: {
+        title: { type: "string", editable: true, maxLength: 120 },
+        description: { type: "string", editable: true, maxLength: 220 },
+        viewAllLabel: { type: "string", editable: true, maxLength: 60 },
+        viewAllHref: { type: "string", editable: true, maxLength: 120 },
+        posts: {
+          type: "array",
+          itemSchema: {
+            title: { type: "string", editable: true, maxLength: 80 },
+            excerpt: { type: "string", editable: true, maxLength: 200 },
+            href: { type: "string", editable: true, maxLength: 120 },
+            author: { type: "string", editable: true, maxLength: 60 },
+            publishDate: { type: "string", editable: true, maxLength: 40 },
+            ctaLabel: { type: "string", editable: true, maxLength: 40 },
+            imageSrc: { type: "image", editable: true },
+            imageAlt: { type: "string", editable: true, maxLength: 120 },
+          },
+        },
+      },
+      defaultData: {
+        title: "Insights and resources",
+        description: "Explore the latest guides and tips from our advisory team.",
+        viewAllLabel: "View all articles",
+        viewAllHref: "/blog",
+        posts: [],
+      },
+    },
+    blogList: {
+      displayName: "Blog List",
+      schema: {
+        title: { type: "string", editable: true, maxLength: 120 },
+        description: { type: "string", editable: true, maxLength: 220 },
+        posts: {
+          type: "array",
+          itemSchema: {
+            title: { type: "string", editable: true, maxLength: 100 },
+            excerpt: { type: "string", editable: true, maxLength: 260 },
+            href: { type: "string", editable: true, maxLength: 120 },
+            author: { type: "string", editable: true, maxLength: 60 },
+            publishDate: { type: "string", editable: true, maxLength: 40 },
+            readingTime: { type: "string", editable: true, maxLength: 30 },
+          },
+        },
+      },
+      defaultData: {
+        title: "Latest articles",
+        description: "Stay updated with guidance from Compass advisors.",
+        posts: [],
+      },
+    },
+    blogArticle: {
+      displayName: "Blog Article",
+      schema: {
+        title: { type: "string", editable: true, maxLength: 160 },
+        author: { type: "string", editable: true, maxLength: 80 },
+        publishDate: { type: "string", editable: true, maxLength: 40 },
+        readingTime: { type: "string", editable: true, maxLength: 30 },
+        featuredImageSrc: { type: "image", editable: true },
+        featuredImageAlt: { type: "string", editable: true, maxLength: 120 },
+        content: { type: "richtext", editable: true },
+      },
+      defaultData: {
+        title: "How to scale your finance operations",
+        author: "Jordan Spencer",
+        publishDate: "2024-04-01",
+        readingTime: "6 min read",
+        featuredImageSrc: "/images/blog-hero.jpg",
+        featuredImageAlt: "Financial planning session",
+        content: "<p>Share your expertise here.</p>",
+      },
+    },
+    serviceHero: {
+      displayName: "Service Hero",
+      schema: {
+        eyebrow: { type: "string", editable: true, maxLength: 80 },
+        title: { type: "string", editable: true, maxLength: 140 },
+        description: { type: "string", editable: true, maxLength: 220 },
+        imageSrc: { type: "image", editable: true },
+        imageAlt: { type: "string", editable: true, maxLength: 120 },
+        ctaLabel: { type: "string", editable: true, maxLength: 40 },
+        ctaHref: { type: "string", editable: true, maxLength: 120 },
+      },
+      defaultData: {
+        eyebrow: "Service",
+        title: "Full-service bookkeeping",
+        description: "Dedicated specialists, tailored workflows, and modern software to keep you audit ready.",
+        imageSrc: "/images/service-hero.jpg",
+        imageAlt: "Professional working on laptop",
+        ctaLabel: "Book a consultation",
+        ctaHref: "/contact",
+      },
+    },
+    serviceDescription: {
+      displayName: "Service Description",
+      schema: {
+        title: { type: "string", editable: true, maxLength: 120 },
+        overview: { type: "string", editable: true, maxLength: 260 },
+        benefits: {
+          type: "array",
+          itemSchema: {
+            title: { type: "string", editable: true, maxLength: 80 },
+            description: { type: "string", editable: true, maxLength: 220 },
+          },
+        },
+      },
+      defaultData: {
+        title: "What’s included",
+        overview: "Comprehensive bookkeeping, reconciliations, and reporting to support leadership decisions.",
+        benefits: [],
+      },
+    },
+    servicePricing: {
+      displayName: "Service Pricing",
+      schema: {
+        title: { type: "string", editable: true, maxLength: 120 },
+        description: { type: "string", editable: true, maxLength: 220 },
+        tiers: {
+          type: "array",
+          itemSchema: {
+            name: { type: "string", editable: true, maxLength: 60 },
+            price: { type: "string", editable: true, maxLength: 40 },
+            features: {
+              type: "array",
+              itemSchema: {
+                value: { type: "string", editable: true, maxLength: 120 },
+              },
+            },
+            ctaLabel: { type: "string", editable: true, maxLength: 40 },
+            ctaHref: { type: "string", editable: true, maxLength: 120 },
+          },
+        },
+      },
+      defaultData: {
+        title: "Tailored plans",
+        description: "Choose the tier that matches your volume and complexity.",
+        tiers: [],
+      },
+    },
+    serviceContact: {
+      displayName: "Service Contact",
+      schema: {
+        title: { type: "string", editable: true, maxLength: 120 },
+        description: { type: "string", editable: true, maxLength: 220 },
+        ctaLabel: { type: "string", editable: true, maxLength: 40 },
+        ctaHref: { type: "string", editable: true, maxLength: 120 },
+        supportDetails: {
+          type: "array",
+          itemSchema: {
+            label: { type: "string", editable: true, maxLength: 60 },
+            value: { type: "string", editable: true, maxLength: 120 },
+            href: { type: "string", editable: true, maxLength: 120 },
+          },
+        },
+      },
+      defaultData: {
+        title: "Let’s build your service plan",
+        description: "Connect with our specialists to receive a custom proposal for this service.",
+        ctaLabel: "Talk to an expert",
+        ctaHref: "/contact",
+        supportDetails: [],
+      },
+    },
+  },
+  pages: {
+    home: {
+      path: "/",
+      allowedSectionTypes: [
+        "header",
+        "hero",
+        "features",
+        "services",
+        "process",
+        "pricing",
+        "testimonials",
+        "blogTeaser",
+        "contact",
+        "footer",
+      ],
+    },
+    "about-us": {
+      path: "/about-us",
+      allowedSectionTypes: ["header", "aboutUsHero", "about", "team", "contact", "footer"],
+    },
+    "blog-index": {
+      path: "/blog",
+      allowedSectionTypes: ["header", "blogList", "footer"],
+    },
+    "blog-post": {
+      path: "/blog/[slug]",
+      allowedSectionTypes: ["header", "blogArticle", "blogTeaser", "contact", "footer"],
+    },
+    "service-detail": {
+      path: "/services/[slug]",
+      allowedSectionTypes: [
+        "header",
+        "serviceHero",
+        "serviceDescription",
+        "servicePricing",
+        "serviceContact",
+        "footer",
+      ],
+    },
+  },
+} as const;
+
+export type SiteSchema = typeof siteSchema;

--- a/theme/sample-site-data.ts
+++ b/theme/sample-site-data.ts
@@ -1,0 +1,996 @@
+export const siteData = {
+  _meta: { locale: "en" },
+  site: { brand: "Compass Accounting", slug: "compass", locale: "en" },
+  features: { blogEnabled: true },
+  pages: {
+    home: {
+      sections: [
+        {
+          id: "header",
+          type: "header",
+          enabled: true,
+          region: "main",
+          order: 10,
+          data: {
+            logoSrc: "/images/logo-mark.svg",
+            logoAlt: "Compass Accounting logo",
+            brandName: "Compass Accounting",
+            navigation: [
+              { label: "Services", href: "/services" },
+              { label: "About", href: "/about-us" },
+              { label: "Process", href: "/#process" },
+              { label: "Resources", href: "/blog" },
+            ],
+            ctaButtons: [
+              { label: "Client login", href: "/login", style: "secondary" },
+              { label: "Book a call", href: "/contact", style: "primary" },
+            ],
+          },
+        },
+        {
+          id: "hero",
+          type: "hero",
+          enabled: true,
+          region: "main",
+          order: 20,
+          data: {
+            eyebrow: "Streamlined accounting",
+            title: "Simplified bookkeeping and advisory for modern accounting firms",
+            description:
+              "Partner with Compass for proactive bookkeeping, tax strategy, and CFO guidance designed to keep your clients ahead.",
+            primaryCtaLabel: "Schedule a consultation",
+            primaryCtaHref: "/contact",
+            secondaryCtaLabel: "View pricing",
+            secondaryCtaHref: "/#pricing",
+            stats: [
+              { label: "Happy clients", value: "320+" },
+              { label: "Average response", value: "< 4 hrs" },
+              { label: "Assets managed", value: "$1.2B" },
+            ],
+            imageSrc: "/images/hero-team.jpg",
+            imageAlt: "Accounting specialists collaborating",
+            partnerLogos: [
+              { src: "/images/logo-client-1.svg", alt: "Client 1" },
+              { src: "/images/logo-client-2.svg", alt: "Client 2" },
+              { src: "/images/logo-client-3.svg", alt: "Client 3" },
+            ],
+          },
+        },
+        {
+          id: "features",
+          type: "features",
+          enabled: true,
+          region: "main",
+          order: 30,
+          data: {
+            eyebrow: "Why Compass",
+            title: "Your trusted partner for adaptive accounting",
+            description:
+              "From day-one setup to enterprise-ready reporting, Compass delivers the tools and team you need to stay confident.",
+            items: [
+              {
+                icon: "/images/icon-insights.svg",
+                title: "Real-time insights",
+                description: "Dashboards and forecasts that keep leadership aligned and confident.",
+              },
+              {
+                icon: "/images/icon-compliance.svg",
+                title: "Compliance assured",
+                description: "Expert guidance to keep you ahead of tax deadlines and regulations.",
+              },
+              {
+                icon: "/images/icon-automation.svg",
+                title: "Automated workflows",
+                description: "Integrated technology removes manual tasks and reduces error.",
+              },
+              {
+                icon: "/images/icon-support.svg",
+                title: "Dedicated support",
+                description: "Partner with a responsive team that understands your business goals.",
+              },
+            ],
+          },
+        },
+        {
+          id: "services",
+          type: "services",
+          enabled: true,
+          region: "main",
+          order: 40,
+          data: {
+            title: "Streamlined servicing for firms of every size",
+            description:
+              "Tailored engagements that flex with seasonal demand and regulatory change.",
+            ctaLabel: "Explore service",
+            services: [
+              {
+                name: "Client bookkeeping",
+                summary: "Full-cycle bookkeeping with reconciliations and monthly close support.",
+                href: "/services/bookkeeping",
+                features: [
+                  { value: "Dedicated account lead" },
+                  { value: "Cloud-based general ledger" },
+                  { value: "KPI dashboards" },
+                ],
+              },
+              {
+                name: "Tax strategy",
+                summary: "Proactive planning, filings, and audit readiness for complex entities.",
+                href: "/services/tax-strategy",
+                features: [
+                  { value: "Quarterly planning sessions" },
+                  { value: "Regulatory monitoring" },
+                  { value: "Audit support" },
+                ],
+              },
+              {
+                name: "Fractional CFO",
+                summary: "Strategic finance guidance to support transactions and fundraising.",
+                href: "/services/fractional-cfo",
+                features: [
+                  { value: "Scenario modeling" },
+                  { value: "Board-ready reporting" },
+                  { value: "Capital strategy" },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          id: "process",
+          type: "process",
+          enabled: true,
+          region: "main",
+          order: 50,
+          data: {
+            title: "Steps in our process",
+            description:
+              "We combine structured onboarding with continuous check-ins to keep engagements on track.",
+            steps: [
+              {
+                title: "Discover",
+                description: "Align on goals, software, and reporting requirements for your firm.",
+              },
+              {
+                title: "Design",
+                description: "Customize workflows, close checklists, and client communication cadences.",
+              },
+              {
+                title: "Deliver",
+                description: "Operate the plan with proactive updates and quarterly optimization reviews.",
+              },
+            ],
+            imageSrc: "/images/process-collaboration.jpg",
+            imageAlt: "Team reviewing documents",
+          },
+        },
+        {
+          id: "pricing",
+          type: "pricing",
+          enabled: true,
+          region: "main",
+          order: 60,
+          data: {
+            title: "Customized pricing tailored to your practice",
+            description:
+              "Choose a plan aligned with your client volume and the outcomes you need from Compass.",
+            plans: [
+              {
+                name: "Core",
+                price: "$1,200/mo",
+                billingNote: "Perfect for growing firms",
+                features: [
+                  { value: "Dedicated bookkeeper" },
+                  { value: "Monthly close" },
+                  { value: "Quarterly tax reviews" },
+                ],
+                ctaLabel: "Start core",
+                ctaHref: "/contact?plan=core",
+                highlighted: false,
+              },
+              {
+                name: "Scale",
+                price: "$2,400/mo",
+                billingNote: "Most popular",
+                features: [
+                  { value: "Controller oversight" },
+                  { value: "Rolling forecasts" },
+                  { value: "Unlimited support" },
+                ],
+                ctaLabel: "Start scale",
+                ctaHref: "/contact?plan=scale",
+                highlighted: true,
+              },
+              {
+                name: "Enterprise",
+                price: "Custom",
+                billingNote: "For complex portfolios",
+                features: [
+                  { value: "Dedicated CFO" },
+                  { value: "Systems integration" },
+                  { value: "On-site workshops" },
+                ],
+                ctaLabel: "Contact sales",
+                ctaHref: "/contact?plan=enterprise",
+                highlighted: false,
+              },
+            ],
+          },
+        },
+        {
+          id: "testimonials",
+          type: "testimonials",
+          enabled: true,
+          region: "main",
+          order: 70,
+          data: {
+            title: "Clients love us",
+            description: "Accountants and finance leaders rely on Compass to stay ahead of every deadline.",
+            testimonials: [
+              {
+                quote: "Compass transformed our month-end process and keeps our partners informed with live dashboards.",
+                author: "Morgan Patel",
+                role: "Managing Partner, Ledger & Co.",
+                avatarSrc: "/images/avatar-morgan.jpg",
+                avatarAlt: "Portrait of Morgan Patel",
+              },
+              {
+                quote: "The team integrates seamlessly with our tech stack and proactively surfaces savings opportunities.",
+                author: "Luis Romero",
+                role: "Director of Finance, Northwind",
+                avatarSrc: "/images/avatar-luis.jpg",
+                avatarAlt: "Portrait of Luis Romero",
+              },
+              {
+                quote: "We finally have forecasts the executive team trusts thanks to Compass’ fractional CFOs.",
+                author: "Taylor James",
+                role: "COO, Horizon Labs",
+                avatarSrc: "/images/avatar-taylor.jpg",
+                avatarAlt: "Portrait of Taylor James",
+              },
+            ],
+          },
+        },
+        {
+          id: "blogTeaser",
+          type: "blogTeaser",
+          enabled: true,
+          region: "main",
+          order: 80,
+          data: {
+            title: "Insights from our experts",
+            description: "Guides and analysis to help you build a forward-looking accounting practice.",
+            viewAllLabel: "Browse all articles",
+            viewAllHref: "/blog",
+            posts: [
+              {
+                title: "Implementing rolling forecasts across your portfolio",
+                excerpt: "Build a forecasting cadence that keeps partners informed and clients prepared.",
+                href: "/blog/rolling-forecasts",
+                author: "Harper Quinn",
+                publishDate: "Mar 18, 2024",
+                ctaLabel: "Read article",
+                imageSrc: "/images/blog-rolling-forecast.jpg",
+                imageAlt: "Person analyzing financial charts",
+              },
+              {
+                title: "Designing a scalable month-end close",
+                excerpt: "A playbook for standardizing workpapers and reducing review cycles.",
+                href: "/blog/month-end-close",
+                author: "Jordan Ellis",
+                publishDate: "Mar 04, 2024",
+                ctaLabel: "Discover how",
+                imageSrc: "/images/blog-month-end.jpg",
+                imageAlt: "Accountant working with laptop",
+              },
+              {
+                title: "How to elevate client communication",
+                excerpt: "Deliver strategic updates that build trust and highlight advisory value.",
+                href: "/blog/client-communication",
+                author: "Sasha Lin",
+                publishDate: "Feb 26, 2024",
+                ctaLabel: "See the framework",
+                imageSrc: "/images/blog-communication.jpg",
+                imageAlt: "Team collaborating in office",
+              },
+            ],
+          },
+        },
+        {
+          id: "contact",
+          type: "contact",
+          enabled: true,
+          region: "main",
+          order: 90,
+          data: {
+            title: "Let’s build your accounting roadmap",
+            description:
+              "Tell us about your current challenges and we’ll outline the Compass plan that fits.",
+            contactMethods: [
+              { label: "Phone", value: "(555) 012-3456", href: "tel:5550123456" },
+              { label: "Email", value: "hello@compass.co", href: "mailto:hello@compass.co" },
+              { label: "Office", value: "845 Market Street, Suite 120", href: "https://maps.example.com/compass" },
+            ],
+            cardTitle: "Ready to get started?",
+            cardDescription: "Share your goals and we’ll deliver a tailored proposal in one business day.",
+            formCtaLabel: "Schedule a call",
+            formCtaHref: "/contact",
+          },
+        },
+        {
+          id: "footer",
+          type: "footer",
+          enabled: true,
+          region: "main",
+          order: 100,
+          data: {
+            logoSrc: "/images/logo-mark.svg",
+            logoAlt: "Compass icon",
+            description: "Streamlined accounting solutions for modern firms.",
+            navigationGroups: [
+              {
+                title: "Company",
+                links: [
+                  { label: "About", href: "/about-us" },
+                  { label: "Careers", href: "/careers" },
+                  { label: "Contact", href: "/contact" },
+                ],
+              },
+              {
+                title: "Services",
+                links: [
+                  { label: "Bookkeeping", href: "/services/bookkeeping" },
+                  { label: "Tax Strategy", href: "/services/tax-strategy" },
+                  { label: "Fractional CFO", href: "/services/fractional-cfo" },
+                ],
+              },
+              {
+                title: "Resources",
+                links: [
+                  { label: "Blog", href: "/blog" },
+                  { label: "Guides", href: "/resources/guides" },
+                  { label: "Events", href: "/resources/events" },
+                ],
+              },
+            ],
+            contactInfo: [
+              { label: "Support", value: "support@compass.co", href: "mailto:support@compass.co" },
+              { label: "Phone", value: "(555) 012-3456", href: "tel:5550123456" },
+            ],
+            copyright: "© 2024 Compass Accounting. All rights reserved.",
+          },
+        },
+      ],
+    },
+    "about-us": {
+      sections: [
+        {
+          id: "header",
+          type: "header",
+          enabled: true,
+          region: "main",
+          order: 10,
+          data: {
+            logoSrc: "/images/logo-mark.svg",
+            logoAlt: "Compass icon",
+            brandName: "Compass Accounting",
+            navigation: [
+              { label: "Services", href: "/services" },
+              { label: "About", href: "/about-us" },
+              { label: "Process", href: "/#process" },
+              { label: "Resources", href: "/blog" },
+            ],
+            ctaButtons: [
+              { label: "Client login", href: "/login", style: "secondary" },
+              { label: "Book a call", href: "/contact", style: "primary" },
+            ],
+          },
+        },
+        {
+          id: "aboutUsHero",
+          type: "aboutUsHero",
+          enabled: true,
+          region: "main",
+          order: 20,
+          data: {
+            eyebrow: "About Compass",
+            title: "We empower accounting teams to lead with confidence",
+            description:
+              "Our multidisciplinary team blends accounting expertise with technology and process design to help firms scale.",
+            primaryCtaLabel: "Meet the team",
+            primaryCtaHref: "/about-us#team",
+            secondaryCtaLabel: "Our services",
+            secondaryCtaHref: "/services",
+            stats: [
+              { label: "Years in business", value: "12" },
+              { label: "Experts on staff", value: "85" },
+              { label: "Client NPS", value: "78" },
+            ],
+            imageSrc: "/images/about-hero.jpg",
+            imageAlt: "Compass team meeting",
+            partnerLogos: [],
+          },
+        },
+        {
+          id: "about",
+          type: "about",
+          enabled: true,
+          region: "main",
+          order: 30,
+          data: {
+            title: "Built for modern accounting leaders",
+            description:
+              "Compass was founded to give firms a proactive partner who understands both compliance and strategic advisory.",
+            highlights: [
+              {
+                title: "Technology-forward",
+                description: "We integrate the latest tools into every engagement while protecting data privacy.",
+              },
+              {
+                title: "Specialist team",
+                description: "Our analysts, CPAs, and CFOs collaborate to support every client touchpoint.",
+              },
+              {
+                title: "Nationwide reach",
+                description: "Remote-first with local specialists available in 18 cities across North America.",
+              },
+            ],
+            imageSrc: "/images/about-collaboration.jpg",
+            imageAlt: "Compass employees collaborating",
+          },
+        },
+        {
+          id: "team",
+          type: "team",
+          enabled: true,
+          region: "main",
+          order: 40,
+          data: {
+            title: "Leadership team",
+            description: "Experienced advisors committed to your success.",
+            members: [
+              {
+                name: "Jamie Carter",
+                role: "Founder & CEO",
+                bio: "CPA with 15 years scaling multi-location accounting practices.",
+                imageSrc: "/images/team-jamie.jpg",
+                imageAlt: "Portrait of Jamie Carter",
+                socialLinks: [
+                  { label: "LinkedIn", href: "https://linkedin.com/in/jamiecarter" },
+                ],
+              },
+              {
+                name: "Priya Desai",
+                role: "Head of Advisory",
+                bio: "Designs financial strategies that unlock growth for complex portfolios.",
+                imageSrc: "/images/team-priya.jpg",
+                imageAlt: "Portrait of Priya Desai",
+                socialLinks: [
+                  { label: "LinkedIn", href: "https://linkedin.com/in/priyadesai" },
+                ],
+              },
+              {
+                name: "Noah Kim",
+                role: "Director of Tax",
+                bio: "Leads a team of specialists keeping clients compliant across jurisdictions.",
+                imageSrc: "/images/team-noah.jpg",
+                imageAlt: "Portrait of Noah Kim",
+                socialLinks: [
+                  { label: "LinkedIn", href: "https://linkedin.com/in/noahkim" },
+                ],
+              },
+              {
+                name: "Avery Ross",
+                role: "VP of Client Success",
+                bio: "Ensures every engagement receives responsive communication and support.",
+                imageSrc: "/images/team-avery.jpg",
+                imageAlt: "Portrait of Avery Ross",
+                socialLinks: [
+                  { label: "LinkedIn", href: "https://linkedin.com/in/averyross" },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          id: "contact",
+          type: "contact",
+          enabled: true,
+          region: "main",
+          order: 50,
+          data: {
+            title: "Connect with our leadership",
+            description: "We’ll pair you with the right specialists for your firm’s goals.",
+            contactMethods: [
+              { label: "Partnerships", value: "partners@compass.co", href: "mailto:partners@compass.co" },
+              { label: "Media", value: "press@compass.co", href: "mailto:press@compass.co" },
+            ],
+            cardTitle: "Join a discovery session",
+            cardDescription: "Choose a time to explore how Compass elevates your accounting services.",
+            formCtaLabel: "Book now",
+            formCtaHref: "/contact",
+          },
+        },
+        {
+          id: "footer",
+          type: "footer",
+          enabled: true,
+          region: "main",
+          order: 60,
+          data: {
+            logoSrc: "/images/logo-mark.svg",
+            logoAlt: "Compass icon",
+            description: "Streamlined accounting solutions for modern firms.",
+            navigationGroups: [
+              {
+                title: "Company",
+                links: [
+                  { label: "About", href: "/about-us" },
+                  { label: "Careers", href: "/careers" },
+                  { label: "Contact", href: "/contact" },
+                ],
+              },
+              {
+                title: "Services",
+                links: [
+                  { label: "Bookkeeping", href: "/services/bookkeeping" },
+                  { label: "Tax Strategy", href: "/services/tax-strategy" },
+                  { label: "Fractional CFO", href: "/services/fractional-cfo" },
+                ],
+              },
+              {
+                title: "Resources",
+                links: [
+                  { label: "Blog", href: "/blog" },
+                  { label: "Guides", href: "/resources/guides" },
+                  { label: "Events", href: "/resources/events" },
+                ],
+              },
+            ],
+            contactInfo: [
+              { label: "Support", value: "support@compass.co", href: "mailto:support@compass.co" },
+              { label: "Phone", value: "(555) 012-3456", href: "tel:5550123456" },
+            ],
+            copyright: "© 2024 Compass Accounting. All rights reserved.",
+          },
+        },
+      ],
+    },
+    "blog-index": {
+      sections: [
+        {
+          id: "header",
+          type: "header",
+          enabled: true,
+          region: "main",
+          order: 10,
+          data: {
+            logoSrc: "/images/logo-mark.svg",
+            logoAlt: "Compass icon",
+            brandName: "Compass Accounting",
+            navigation: [
+              { label: "Services", href: "/services" },
+              { label: "About", href: "/about-us" },
+              { label: "Process", href: "/#process" },
+              { label: "Resources", href: "/blog" },
+            ],
+            ctaButtons: [
+              { label: "Client login", href: "/login", style: "secondary" },
+              { label: "Book a call", href: "/contact", style: "primary" },
+            ],
+          },
+        },
+        {
+          id: "blogList",
+          type: "blogList",
+          enabled: true,
+          region: "main",
+          order: 20,
+          data: {
+            title: "Compass insights",
+            description: "Deep dives and practical resources for accounting leaders.",
+            posts: [
+              {
+                title: "Building a resilient accounting tech stack",
+                excerpt: "How to assess, select, and rollout new software without disrupting your team.",
+                href: "/blog/accounting-tech-stack",
+                author: "Rowan Blake",
+                publishDate: "Mar 11, 2024",
+                readingTime: "8 min read",
+              },
+              {
+                title: "When to introduce fractional CFO support",
+                excerpt: "Signals that your clients are ready for strategic finance guidance.",
+                href: "/blog/fractional-cfo-support",
+                author: "Imani Wells",
+                publishDate: "Feb 27, 2024",
+                readingTime: "7 min read",
+              },
+              {
+                title: "Standardizing workpapers across offices",
+                excerpt: "A framework for consistent documentation that reduces review time.",
+                href: "/blog/standardizing-workpapers",
+                author: "Devin Hart",
+                publishDate: "Feb 12, 2024",
+                readingTime: "6 min read",
+              },
+            ],
+          },
+        },
+        {
+          id: "footer",
+          type: "footer",
+          enabled: true,
+          region: "main",
+          order: 30,
+          data: {
+            logoSrc: "/images/logo-mark.svg",
+            logoAlt: "Compass icon",
+            description: "Streamlined accounting solutions for modern firms.",
+            navigationGroups: [
+              {
+                title: "Company",
+                links: [
+                  { label: "About", href: "/about-us" },
+                  { label: "Careers", href: "/careers" },
+                  { label: "Contact", href: "/contact" },
+                ],
+              },
+              {
+                title: "Services",
+                links: [
+                  { label: "Bookkeeping", href: "/services/bookkeeping" },
+                  { label: "Tax Strategy", href: "/services/tax-strategy" },
+                  { label: "Fractional CFO", href: "/services/fractional-cfo" },
+                ],
+              },
+              {
+                title: "Resources",
+                links: [
+                  { label: "Blog", href: "/blog" },
+                  { label: "Guides", href: "/resources/guides" },
+                  { label: "Events", href: "/resources/events" },
+                ],
+              },
+            ],
+            contactInfo: [
+              { label: "Support", value: "support@compass.co", href: "mailto:support@compass.co" },
+              { label: "Phone", value: "(555) 012-3456", href: "tel:5550123456" },
+            ],
+            copyright: "© 2024 Compass Accounting. All rights reserved.",
+          },
+        },
+      ],
+    },
+    "blog-post": {
+      sections: [
+        {
+          id: "header",
+          type: "header",
+          enabled: true,
+          region: "main",
+          order: 10,
+          data: {
+            logoSrc: "/images/logo-mark.svg",
+            logoAlt: "Compass icon",
+            brandName: "Compass Accounting",
+            navigation: [
+              { label: "Services", href: "/services" },
+              { label: "About", href: "/about-us" },
+              { label: "Process", href: "/#process" },
+              { label: "Resources", href: "/blog" },
+            ],
+            ctaButtons: [
+              { label: "Client login", href: "/login", style: "secondary" },
+              { label: "Book a call", href: "/contact", style: "primary" },
+            ],
+          },
+        },
+        {
+          id: "blogArticle",
+          type: "blogArticle",
+          enabled: true,
+          region: "main",
+          order: 20,
+          data: {
+            title: "Implementing rolling forecasts across your client portfolio",
+            author: "Harper Quinn",
+            publishDate: "Mar 18, 2024",
+            readingTime: "6 min read",
+            featuredImageSrc: "/images/blog-rolling-forecast.jpg",
+            featuredImageAlt: "Professional reviewing financial reports",
+            content:
+              "<p>Rolling forecasts provide the agility accounting leaders need to navigate uncertainty. Start by aligning stakeholders on cadence and data sources, then introduce scenario planning to evaluate risk and opportunity.</p><p>Compass equips teams with templates, integrations, and advisory support to operationalize forecasts across every engagement.</p>",
+          },
+        },
+        {
+          id: "blogTeaser",
+          type: "blogTeaser",
+          enabled: true,
+          region: "main",
+          order: 30,
+          data: {
+            title: "More resources for ambitious firms",
+            description: "Keep exploring frameworks and best practices from Compass advisors.",
+            viewAllLabel: "View the library",
+            viewAllHref: "/blog",
+            posts: [
+              {
+                title: "Designing a scalable month-end close",
+                excerpt: "A playbook for standardizing workpapers and reducing review cycles.",
+                href: "/blog/month-end-close",
+                author: "Jordan Ellis",
+                publishDate: "Mar 04, 2024",
+                ctaLabel: "Read next",
+                imageSrc: "/images/blog-month-end.jpg",
+                imageAlt: "Accounting team collaborating",
+              },
+              {
+                title: "Building stronger client relationships",
+                excerpt: "Communication strategies that highlight advisory value.",
+                href: "/blog/client-relationships",
+                author: "Sasha Lin",
+                publishDate: "Feb 22, 2024",
+                ctaLabel: "Explore tips",
+                imageSrc: "/images/blog-communication.jpg",
+                imageAlt: "Two people discussing financial plans",
+              },
+              {
+                title: "Automating accounts payable workflows",
+                excerpt: "Reduce manual effort with a modern AP technology stack.",
+                href: "/blog/automating-ap",
+                author: "Devin Hart",
+                publishDate: "Feb 10, 2024",
+                ctaLabel: "See how",
+                imageSrc: "/images/blog-ap.jpg",
+                imageAlt: "Accountant reviewing invoices",
+              },
+            ],
+          },
+        },
+        {
+          id: "contact",
+          type: "contact",
+          enabled: true,
+          region: "main",
+          order: 40,
+          data: {
+            title: "Talk through these insights with our team",
+            description: "We’ll help you apply these ideas across your clients and services.",
+            contactMethods: [
+              { label: "Phone", value: "(555) 012-3456", href: "tel:5550123456" },
+              { label: "Email", value: "hello@compass.co", href: "mailto:hello@compass.co" },
+            ],
+            cardTitle: "Ready to accelerate?",
+            cardDescription: "Share your goals and we’ll pair you with the right advisor.",
+            formCtaLabel: "Book a strategy call",
+            formCtaHref: "/contact",
+          },
+        },
+        {
+          id: "footer",
+          type: "footer",
+          enabled: true,
+          region: "main",
+          order: 50,
+          data: {
+            logoSrc: "/images/logo-mark.svg",
+            logoAlt: "Compass icon",
+            description: "Streamlined accounting solutions for modern firms.",
+            navigationGroups: [
+              {
+                title: "Company",
+                links: [
+                  { label: "About", href: "/about-us" },
+                  { label: "Careers", href: "/careers" },
+                  { label: "Contact", href: "/contact" },
+                ],
+              },
+              {
+                title: "Services",
+                links: [
+                  { label: "Bookkeeping", href: "/services/bookkeeping" },
+                  { label: "Tax Strategy", href: "/services/tax-strategy" },
+                  { label: "Fractional CFO", href: "/services/fractional-cfo" },
+                ],
+              },
+              {
+                title: "Resources",
+                links: [
+                  { label: "Blog", href: "/blog" },
+                  { label: "Guides", href: "/resources/guides" },
+                  { label: "Events", href: "/resources/events" },
+                ],
+              },
+            ],
+            contactInfo: [
+              { label: "Support", value: "support@compass.co", href: "mailto:support@compass.co" },
+              { label: "Phone", value: "(555) 012-3456", href: "tel:5550123456" },
+            ],
+            copyright: "© 2024 Compass Accounting. All rights reserved.",
+          },
+        },
+      ],
+    },
+    "service-detail": {
+      sections: [
+        {
+          id: "header",
+          type: "header",
+          enabled: true,
+          region: "main",
+          order: 10,
+          data: {
+            logoSrc: "/images/logo-mark.svg",
+            logoAlt: "Compass icon",
+            brandName: "Compass Accounting",
+            navigation: [
+              { label: "Services", href: "/services" },
+              { label: "About", href: "/about-us" },
+              { label: "Process", href: "/#process" },
+              { label: "Resources", href: "/blog" },
+            ],
+            ctaButtons: [
+              { label: "Client login", href: "/login", style: "secondary" },
+              { label: "Book a call", href: "/contact", style: "primary" },
+            ],
+          },
+        },
+        {
+          id: "serviceHero",
+          type: "serviceHero",
+          enabled: true,
+          region: "main",
+          order: 20,
+          data: {
+            eyebrow: "Service spotlight",
+            title: "Client bookkeeping that scales with you",
+            description:
+              "From daily reconciliations to investor-ready reports, Compass handles the numbers so your firm can focus on clients.",
+            imageSrc: "/images/service-bookkeeping.jpg",
+            imageAlt: "Bookkeeping professional",
+            ctaLabel: "Start the conversation",
+            ctaHref: "/contact?service=bookkeeping",
+          },
+        },
+        {
+          id: "serviceDescription",
+          type: "serviceDescription",
+          enabled: true,
+          region: "main",
+          order: 30,
+          data: {
+            title: "What’s included in bookkeeping",
+            overview:
+              "We become an extension of your team, delivering accurate books, fast closes, and insight-rich reporting.",
+            benefits: [
+              {
+                title: "Full-cycle bookkeeping",
+                description: "Daily reconciliations, AP/AR processing, and month-end close.",
+              },
+              {
+                title: "Quality control",
+                description: "Review layers and variance analysis to ensure accuracy every cycle.",
+              },
+              {
+                title: "Insightful reporting",
+                description: "Dashboards, KPIs, and tailored reports for partners and clients.",
+              },
+              {
+                title: "Technology integration",
+                description: "Implementation and optimization of leading accounting platforms.",
+              },
+            ],
+          },
+        },
+        {
+          id: "servicePricing",
+          type: "servicePricing",
+          enabled: true,
+          region: "main",
+          order: 40,
+          data: {
+            title: "Bookkeeping pricing",
+            description: "Pricing adjusts with your client count and transaction volume.",
+            tiers: [
+              {
+                name: "Launch",
+                price: "$900/mo",
+                features: [
+                  { value: "Up to 5 entities" },
+                  { value: "Monthly reporting" },
+                  { value: "Email support" },
+                ],
+                ctaLabel: "Choose launch",
+                ctaHref: "/contact?plan=launch",
+              },
+              {
+                name: "Growth",
+                price: "$1,600/mo",
+                features: [
+                  { value: "Up to 12 entities" },
+                  { value: "Bi-weekly reporting" },
+                  { value: "Slack support" },
+                ],
+                ctaLabel: "Choose growth",
+                ctaHref: "/contact?plan=growth",
+              },
+              {
+                name: "Premier",
+                price: "Custom",
+                features: [
+                  { value: "Unlimited entities" },
+                  { value: "Weekly reporting" },
+                  { value: "Dedicated controller" },
+                ],
+                ctaLabel: "Talk to sales",
+                ctaHref: "/contact?plan=premier",
+              },
+            ],
+          },
+        },
+        {
+          id: "serviceContact",
+          type: "serviceContact",
+          enabled: true,
+          region: "main",
+          order: 50,
+          data: {
+            title: "Let’s craft your bookkeeping plan",
+            description: "Share your goals and we’ll assemble the team to get you there.",
+            ctaLabel: "Schedule a call",
+            ctaHref: "/contact?service=bookkeeping",
+            supportDetails: [
+              { label: "Email", value: "hello@compass.co", href: "mailto:hello@compass.co" },
+              { label: "Phone", value: "(555) 012-3456", href: "tel:5550123456" },
+              { label: "Office", value: "845 Market Street, Suite 120", href: "https://maps.example.com/compass" },
+            ],
+          },
+        },
+        {
+          id: "footer",
+          type: "footer",
+          enabled: true,
+          region: "main",
+          order: 60,
+          data: {
+            logoSrc: "/images/logo-mark.svg",
+            logoAlt: "Compass icon",
+            description: "Streamlined accounting solutions for modern firms.",
+            navigationGroups: [
+              {
+                title: "Company",
+                links: [
+                  { label: "About", href: "/about-us" },
+                  { label: "Careers", href: "/careers" },
+                  { label: "Contact", href: "/contact" },
+                ],
+              },
+              {
+                title: "Services",
+                links: [
+                  { label: "Bookkeeping", href: "/services/bookkeeping" },
+                  { label: "Tax Strategy", href: "/services/tax-strategy" },
+                  { label: "Fractional CFO", href: "/services/fractional-cfo" },
+                ],
+              },
+              {
+                title: "Resources",
+                links: [
+                  { label: "Blog", href: "/blog" },
+                  { label: "Guides", href: "/resources/guides" },
+                  { label: "Events", href: "/resources/events" },
+                ],
+              },
+            ],
+            contactInfo: [
+              { label: "Support", value: "support@compass.co", href: "mailto:support@compass.co" },
+              { label: "Phone", value: "(555) 012-3456", href: "tel:5550123456" },
+            ],
+            copyright: "© 2024 Compass Accounting. All rights reserved.",
+          },
+        },
+      ],
+    },
+  },
+} as const;


### PR DESCRIPTION
## Summary
- add reusable section components that mirror the provided accounting theme design with fully data-driven props
- compose home, about, blog, and service detail content pages from the new sections
- define a provisional site schema and sample data set to support future live editing workflows

## Testing
- `npm run build` *(fails: Next.js could not fetch Google Fonts in this offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2296074c08324a98e3877116a3059